### PR TITLE
update/go tarantool lib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 
 # tt
 .rocks
+*.snap
+*.xlog
+*.log

--- a/api.go
+++ b/api.go
@@ -121,15 +121,9 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 		r.log().Info(ctx, fmt.Sprintf("try call replicaset %s", rs.info.Name))
 
 		future := rs.conn.Do(req, opts.PoolMode)
-		if future.Err() != nil {
-			err = future.Err()
-			r.log().Error(ctx, fmt.Sprintf("got future error: %s", err))
-
-			continue
-		}
-
 		respData, err := future.Get()
 		if err != nil {
+			r.log().Error(ctx, fmt.Sprintf("got future error: %s", err))
 			r.metrics().RetryOnCall("future_get_error")
 
 			continue
@@ -264,7 +258,7 @@ func (r *Router) RouterMapCallRWImpl(
 			conn := replicaset.conn
 
 			future := conn.Do(req, pool.RW)
-			if err := future.Err(); err != nil {
+			if _, err := future.Get(); err != nil {
 				cancel()
 
 				return fmt.Errorf("rs {%s} storage_ref err: %s", id.String(), err.Error())
@@ -350,7 +344,7 @@ func (r *Router) RouterMapCallRWImpl(
 			conn := replicaset.conn
 
 			future := conn.Do(req, pool.RW)
-			if err := future.Err(); err != nil {
+			if _, err := future.Get(); err != nil {
 				cancel()
 
 				return fmt.Errorf("rs {%s} storage_map err: %s", id.String(), err.Error())

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0
 	github.com/snksoft/crc v1.1.0
 	github.com/stretchr/testify v1.8.4
-	github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac
+	github.com/tarantool/go-tarantool/v2 v2.1.0
 	golang.org/x/sync v0.6.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/tarantool/go-iproto v1.0.0 h1:quC4hdFhCuFYaCqOFgUxH2foRkhAy+TlEy7gQLh
 github.com/tarantool/go-iproto v1.0.0/go.mod h1:LNCtdyZxojUed8SbOiYHoc3v9NvaZTB7p96hUySMlIo=
 github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac h1:5yuBAXF4W++mVj2Vcc99zgwdfgLSzyWrQmj/umDLFB4=
 github.com/tarantool/go-tarantool/v2 v2.0.0-20240208121257-f33032e7d0ac/go.mod h1:fBXE0XRt/jiAoDdk2zMQzkNQOWrVnz3rfscIhgRPFqA=
+github.com/tarantool/go-tarantool/v2 v2.1.0 h1:IY33WoS8Kqb+TxNnKbzu/7yVkiCNZGhbG5Gw0/tMfSk=
+github.com/tarantool/go-tarantool/v2 v2.1.0/go.mod h1:cpjGW5FHAXIMf0PKZte70pMOeadw1MA/hrDv1LblWk4=
 github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9znI5mJU=
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=


### PR DESCRIPTION
- update go-tarantool lib to 2.1
- update interface usage
- add tmp tnt files to gitignore