### PR TITLE
Fix buckets discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
+## Unreleased
+
+BUG FIXES:
+
+* Fix buckets discovery (it doesn't freeze now)
+
 ## 0.0.11
 
 FEATURES:
+
 * BucketStat has become a public method (#21)
 
 REFACTOR:

--- a/discovery.go
+++ b/discovery.go
@@ -203,8 +203,9 @@ func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 					knownBucket.Add(1)
 				}
 
-				// if TotalBucketCount < BUCKET_CHUNK_SIZE then nextFrom equal zero
-				if rawReq.From == *nextFrom {
+				// There are no more buckets
+				// https://github.com/tarantool/vshard/blob/8d299bfe/vshard/storage/init.lua#L1730
+				if nextFrom == nil || *nextFrom == 0 {
 					return nil
 				}
 


### PR DESCRIPTION
The `vshard.storage.buckets_discovery` function does not return the `next_from` field if the response does not contain a full batch of buckets. Therefore, if there is no `next_from`, then this means that discovery has ended.