### PR TITLE
resolve several issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ BUG FIXES:
 * DiscoveryAllBuckets returns nil even if errGr.Wait() returns err, fixed
 * DiscoveryHandleBuckets: misusage of atomics, fixed
 * race when accessing to idToReplicaset, fixed: idToReplicaset is immutable object now
+* RouterMapCallRWImpl: fix misusage of refID atomic
+* RouterMapCallRWImpl: decode bucketCount into 32 bit integer instead of 16 bit
+* RouterMapCallRWImpl: fix concurrent access to idToResult map
+* BucketDiscovery: fix possible concurrent access to resultRs and err vars
 
 FEATURES:
 

--- a/vshard.go
+++ b/vshard.go
@@ -114,8 +114,6 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 		knownBucketCount: atomic.Int32{},
 	}
 
-	router.knownBucketCount.Store(0)
-
 	err = cfg.TopologyProvider.Init(router.Topology())
 	if err != nil {
 		router.log().Error(ctx, fmt.Sprintf("cant create new topology provider with err: %s", err))
@@ -142,7 +140,7 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 	}
 
 	nWorkers := int32(2)
-	if cfg.NWorkers != 0 {
+	if cfg.NWorkers > 0 {
 		nWorkers = cfg.NWorkers
 	}
 


### PR DESCRIPTION
* use return value of refID.Add() because race is possible in case of refID.Load() + refID.Add()
* use int32 for bucketCount on decoding 'storage_ref' response because uint16 (max 65535) is too small. We may have some dev cluster with million buckets that are distributed over two shards
* RouterMapCallRWImpl: modify idToResult under mutex to prevent concurrent modifications
* BucketDiscovery: use atomic to acquire the result of BucketSet