### PR TITLE
resolve issue #48

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,14 @@
 ## Unreleased
 
+FEATURES:
+
+* Support new Sprintf-like logging interface (#48)
+
 REFACTOR:
 
 * resolve issue #38: simplify DiscoveryAllBuckets and remove suspicious if
 * resolve issue #46: drastically simplify RouterMapCallRWImpl and added tests with real tnt
+* Use typed nil pointers instead of memory allocation for EmptyMetrics and emptyLogger structs
 
 ## 0.0.12
 

--- a/api_test.go
+++ b/api_test.go
@@ -16,8 +16,8 @@ import (
 var emptyRouter = &Router{
 	cfg: Config{
 		TotalBucketCount: uint64(10),
-		Logger:           &EmptyLogger{},
-		Metrics:          &EmptyMetrics{},
+		Loggerf:          emptyLogfProvider,
+		Metrics:          emptyMetricsProvider,
 	},
 }
 
@@ -48,8 +48,8 @@ func TestRouter_RouterCallImpl(t *testing.T) {
 		r := &Router{
 			cfg: Config{
 				TotalBucketCount: uint64(10),
-				Logger:           &EmptyLogger{},
-				Metrics:          &EmptyMetrics{},
+				Loggerf:          emptyLogfProvider,
+				Metrics:          emptyMetricsProvider,
 			},
 			view: &consistentView{
 				routeMap: make([]atomic.Pointer[Replicaset], 11),

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -14,7 +14,7 @@ func TestRouter_BucketResolve_InvalidBucketID(t *testing.T) {
 	r := Router{
 		cfg: Config{
 			TotalBucketCount: uint64(10),
-			Logger:           &EmptyLogger{},
+			Loggerf:          emptyLogfProvider,
 		},
 		view: &consistentView{
 			routeMap: make([]atomic.Pointer[Replicaset], 11),


### PR DESCRIPTION
* support new Sprintf-like logging interface
* use typed nil pointers instead of memory allocation for EmptyMetrics and emptyLogger structs
* do not export EmptyLogger anymore, because it is the default behavior