### PR TITLE
resolve issue #71

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ BUG FIXES:
 FEATURES:
 
 * Support StdoutLoggerf that allows control log level (resolve issue #84).
+* Support new BucketsSearchMode config to set policy for BucketDiscovery (resolve #71).
+
+REFACTOR:
+
+* Func bucketSearchLegacy: log error from bucketStatWait (except bucketStatError).
+* New bucketsDiscoveryAsync, bucketsDiscoveryWait, bucketsDiscovery methods for buckets discovery pagination.
+* Support bucketSearchBatched method for batched buckets discovery (resolve #71).
+
+TESTS:
+* Tests for BucketsSearchMode (tnt/discovery_test.go).
 
 ## v1.1.0
 

--- a/replicaset.go
+++ b/replicaset.go
@@ -145,3 +145,43 @@ func (rs *Replicaset) CallAsync(ctx context.Context, opts ReplicasetCallOpts, fn
 
 	return rs.conn.Do(req, opts.PoolMode)
 }
+
+func (rs *Replicaset) bucketsDiscoveryAsync(ctx context.Context, from uint64) *tarantool.Future {
+	const bucketsDiscoveryFnc = "vshard.storage.buckets_discovery"
+
+	var bucketsDiscoveryPaginationRequest = struct {
+		From uint64 `msgpack:"from"`
+	}{From: from}
+
+	req := tarantool.NewCallRequest(bucketsDiscoveryFnc).
+		Context(ctx).
+		Args([]interface{}{&bucketsDiscoveryPaginationRequest})
+
+	future := rs.conn.Do(req, pool.PreferRO)
+
+	return future
+}
+
+type bucketsDiscoveryResp struct {
+	Buckets  []uint64 `msgpack:"buckets"`
+	NextFrom uint64   `msgpack:"next_from"`
+}
+
+func bucketsDiscoveryWait(future *tarantool.Future) (bucketsDiscoveryResp, error) {
+	// We intentionally don't support old vshard storages that mentioned here:
+	// https://github.com/tarantool/vshard/blob/8d299bfecff8bc656056658350ad48c829f9ad3f/vshard/router/init.lua#L343
+	var resp bucketsDiscoveryResp
+
+	err := future.GetTyped(&[]interface{}{&resp})
+	if err != nil {
+		return resp, fmt.Errorf("future.GetTyped() failed: %v", err)
+	}
+
+	return resp, nil
+}
+
+func (rs *Replicaset) bucketsDiscovery(ctx context.Context, from uint64) (bucketsDiscoveryResp, error) {
+	future := rs.bucketsDiscoveryAsync(ctx, from)
+
+	return bucketsDiscoveryWait(future)
+}

--- a/vshard.go
+++ b/vshard.go
@@ -96,6 +96,11 @@ type Config struct {
 	DiscoveryTimeout time.Duration
 	DiscoveryMode    DiscoveryMode
 
+	// BucketsSearchMode defines policy for BucketDiscovery method.
+	// Default value is BucketsSearchLegacy.
+	// See BucketsSearchMode constants for more detail.
+	BucketsSearchMode BucketsSearchMode
+
 	TotalBucketCount uint64
 	User             string
 	Password         string


### PR DESCRIPTION
* support new BucketsSearchMode config to set policy for BucketDiscovery
* bucketSearchLegacy: log error from bucketStatWait (except bucketStatError)
* new bucketsDiscoveryAsync, bucketsDiscoveryWait, bucketsDiscovery methods for buckets discovery pagination
* support bucketSearchBatched method for batched buckets discovery
* tnt/discovery_test.go: tests for BucketsSearchMode

resolve #71 