### PR TITLE
fix etcd provider and router context usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## Unreleased
 
+CHANGES:
+* now if there is no etcd connection - etcd provider returns you error instead panic.
+* etcd provider also accepts context as input for working with the logger.
+
+BUG FIXES:
+* fixed the problem of re-creating a new context when starting discovery, which led to a lack of discovery logging.
+
 TESTS:
 
 * Simplify test/tnt/{Makefile,router.lua)

--- a/vshard.go
+++ b/vshard.go
@@ -172,7 +172,7 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 	}
 
 	if cfg.DiscoveryMode == DiscoveryModeOn {
-		discoveryCronCtx, cancelFunc := context.WithCancel(context.Background())
+		discoveryCronCtx, cancelFunc := context.WithCancel(ctx)
 
 		// run background cron discovery loop
 		// suppress linter warning: Non-inherited new context, use function like `context.WithXXX` instead (contextcheck)


### PR DESCRIPTION
- now if there is no etcd connection - etcd provider returns you error instead panic.
- etcd provider also accepts context as input for working with the logger.
- fixed the problem of re-creating a new context when starting discovery, which led to a lack of discovery logging.
