### PR TITLE
add make help command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,26 @@
+# Default timeout for tests
 TEST_TIMEOUT?=100s
+# Timeout for extended tests
 EXTENDED_TEST_TIMEOUT=1m
+# Command to invoke Go
 GO_CMD?=go
+# Path to local binary output directory
 LOCAL_BIN:=$(CURDIR)/bin
-# golang-ci tag
+# Version tag for golangci-lint
 GOLANGCI_TAG:=latest
-# golang-ci bin file path
+# Path to the golangci-lint binary
 GOLANGCI_BIN:=$(GOPATH)/bin/golangci-lint
+
+
+# HELP
+# This will output the help for each task
+# thanks to https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
+
+.DEFAULT_GOAL := help
+
+help: ## This help.
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
 .PHONY: install-lint
 install-lint:
@@ -25,7 +40,7 @@ test: prepare-tnt
 	@rm coverage.out.tmp
 	@$(MAKE) -C ./tests/tnt cluster-down
 
-cover: test
+cover: test ## Generate and open the HTML report for test coverage.
 	 $(GO_CMD) tool cover -html=coverage.out
 
 test/integration:
@@ -36,7 +51,7 @@ generate/mocks:
 	mockery --name=TopologyController --case=underscore --output=mocks/topology --outpkg=mocktopology
 
 .PHONY: lint
-lint: install-lint
+lint: install-lint ## Run GolangCI-Lint to check code quality and style.
 	$(GOLANGCI_BIN) run --config=.golangci.yaml ./...
 
 testrace: BUILD_TAGS+=testonly


### PR DESCRIPTION
**What has been done?**

In this pull request, I've implemented a make help command that provides a clear overview of all available make targets and their descriptions. Additionally, I have improved the comments throughout the Makefile for better clarity and understanding.

**Why?**

The primary goal is to enhance the usability of the Makefile for developers

**What problem is being solved?**

Previously, the lack of documentation and comments made it challenging for new team members to understand the functionality of the Makefile.