### PR TITLE
resolve issue #93

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+FEATURES:
+
+* Add pause between requests in buckets discovering. Configured by config DiscoveryWorkStep, default is 10ms.
+
 ## v1.2.0
 
 CHANGES:

--- a/discovery.go
+++ b/discovery.go
@@ -261,6 +261,10 @@ func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 				}
 
 				bucketsDiscoveryPaginationFrom = resp.NextFrom
+
+				// Don't spam many requests at once. Give storages time to handle them and other requests.
+				// https://github.com/tarantool/vshard/blob/b6fdbe950a2e4557f05b83bd8b846b126ec3724e/vshard/router/init.lua#L308
+				time.Sleep(r.cfg.DiscoveryWorkStep)
 			}
 		})
 	}

--- a/vshard.go
+++ b/vshard.go
@@ -95,6 +95,9 @@ type Config struct {
 	// DiscoveryTimeout is timeout between cron discovery job; by default there is no timeout.
 	DiscoveryTimeout time.Duration
 	DiscoveryMode    DiscoveryMode
+	// DiscoveryWorkStep is a pause between calling buckets_discovery on storage
+	// in buckets discovering logic. Default is 10ms.
+	DiscoveryWorkStep time.Duration
 
 	// BucketsSearchMode defines policy for BucketDiscovery method.
 	// Default value is BucketsSearchLegacy.
@@ -234,6 +237,7 @@ func (r *Router) RouteMapClean() {
 
 func prepareCfg(ctx context.Context, cfg Config) (Config, error) {
 	const discoveryTimeoutDefault = 1 * time.Minute
+	const discoveryWorkStepDefault = 10 * time.Millisecond
 
 	err := validateCfg(cfg)
 	if err != nil {
@@ -256,6 +260,10 @@ func prepareCfg(ctx context.Context, cfg Config) (Config, error) {
 
 	if cfg.Metrics == nil {
 		cfg.Metrics = emptyMetricsProvider
+	}
+
+	if cfg.DiscoveryWorkStep == 0 {
+		cfg.DiscoveryWorkStep = discoveryWorkStepDefault
 	}
 
 	return cfg, nil


### PR DESCRIPTION
What has been done? Why? What problem is being solved?

* Add a pause between bucketsDiscovery requests (default is 10 ms), see #93

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues: #93 
