### PR TITLE
resolve issue #75

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -13,6 +13,25 @@ linters-settings:
   goconst:
     min-len:         2
     min-occurrences: 2
+  revive:
+    rules:
+      - name: string-format
+        severity: error
+        disabled: false
+        arguments:
+          - - 'fmt.Errorf[0]'
+            - "/^[^A-Z].*$/"
+            - error messages must not start with capital letter
+          - - 'log.Printf[0]'
+            - "/^[^a-z].*$/"
+            - log messages must not start with lowercase letter
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+    ignore-words:
+      - GitLab
 
 linters:
   disable-all: true
@@ -40,3 +59,4 @@ linters:
     - nilerr
     - nilnil
     - usestdlibvars
+    - misspell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ BUG FIXES:
 CHANGES:
 * Add comment why and how we handle "NON_MASTER" vshard error.
 * Don't support 'type Error struct' anymore.
+* Linter: don't capitalize error strings and capitalize log.
+* Fix misspellings.
 
 FEATURES:
 

--- a/api.go
+++ b/api.go
@@ -113,7 +113,7 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 		if since := time.Since(timeStart); since > timeout {
 			r.metrics().RequestDuration(since, false, false)
 
-			r.log().Debugf(ctx, "return result on timeout; since %s of timeout %s", since, timeout)
+			r.log().Debugf(ctx, "Return result on timeout; since %s of timeout %s", since, timeout)
 			if err == nil {
 				err = fmt.Errorf("cant get call cause call impl timeout")
 			}
@@ -136,7 +136,7 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 			continue
 		}
 
-		r.log().Infof(ctx, "try call %s on replicaset %s for bucket %d", fnc, rs.info.Name, bucketID)
+		r.log().Infof(ctx, "Try call %s on replicaset %s for bucket %d", fnc, rs.info.Name, bucketID)
 
 		future := rs.conn.Do(req, opts.PoolMode)
 
@@ -146,7 +146,7 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 			return nil, nil, fmt.Errorf("got error on future.Get(): %w", err)
 		}
 
-		r.log().Debugf(ctx, "got call result response data %v", respData)
+		r.log().Debugf(ctx, "Got call result response data %v", respData)
 
 		if len(respData) == 0 {
 			// vshard.storage.call(func) returns up to two values:
@@ -177,7 +177,7 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 				// So we just retry here as a temporary solution.
 				r.metrics().RetryOnCall("bucket_migrate")
 
-				r.log().Debugf(ctx, "retrying fnc '%s' cause got vshard error: %v", fnc, &vshardError)
+				r.log().Debugf(ctx, "Retrying fnc '%s' cause got vshard error: %v", fnc, &vshardError)
 
 				// this vshardError will be returned to a caller in case of timeout
 				err = &vshardError

--- a/discovery.go
+++ b/discovery.go
@@ -26,7 +26,7 @@ const (
 )
 
 // BucketsSearchMode a type, that used to define policy for BucketDiscovery method.
-// See type Config for futher details.
+// See type Config for further details.
 type BucketsSearchMode int
 
 const (
@@ -226,7 +226,7 @@ func (r *Router) DiscoveryHandleBuckets(ctx context.Context, rs *Replicaset, buc
 func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 	t := time.Now()
 
-	r.log().Infof(ctx, "start discovery all buckets")
+	r.log().Infof(ctx, "Start discovery all buckets")
 
 	errGr, ctx := errgroup.WithContext(ctx)
 
@@ -273,7 +273,7 @@ func (r *Router) DiscoveryAllBuckets(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("errGr.Wait() err: %w", err)
 	}
-	r.log().Infof(ctx, "discovery done since: %s", time.Since(t))
+	r.log().Infof(ctx, "Discovery done since: %s", time.Since(t))
 
 	return nil
 }
@@ -294,7 +294,7 @@ func (r *Router) cronDiscovery(ctx context.Context) {
 
 		// Since the current for loop should not stop until ctx->Done() event fires,
 		// we should be able to continue execution even a panic occures.
-		// Therefore, we should wrap everyting into anonymous function that recovers after panic.
+		// Therefore, we should wrap everything into anonymous function that recovers after panic.
 		// (Similar to pcall in lua/tarantool)
 		func() {
 			defer func() {

--- a/logger.go
+++ b/logger.go
@@ -57,11 +57,11 @@ func (l tarantoolOptsLogger) Report(event tarantool.ConnLogKind, conn *tarantool
 
 		if headerOk {
 			l.loggerf.Errorf(l.ctx, "tarantool: connection %s got unexpected resultId (%d) in response"+
-				"(probably cancelled request)",
+				"(probably canceled request)",
 				conn.Addr(), header.RequestId)
 		} else {
 			l.loggerf.Errorf(l.ctx, "tarantool: connection %s got unexpected resultId in response"+
-				"(probably cancelled request) (unexpected v... format): %+v",
+				"(probably canceled request) (unexpected v... format): %+v",
 				conn.Addr(), v)
 		}
 	case tarantool.LogWatchEventReadFailed:

--- a/providers/viper/provider.go
+++ b/providers/viper/provider.go
@@ -45,7 +45,7 @@ func NewProvider(v *srcviper.Viper) *Provider {
 	for rsName, rs := range cfg.Topology.Clusters {
 		rsUUID, err := uuid.Parse(rs.ReplicasetUUID)
 		if err != nil {
-			log.Printf("cant parse replicaset uuid: %s", err)
+			log.Printf("Can't parse replicaset uuid: %s", err)
 
 			os.Exit(2)
 		}
@@ -59,7 +59,7 @@ func NewProvider(v *srcviper.Viper) *Provider {
 
 			instUUID, err := uuid.Parse(instInfo.Box.InstanceUUID)
 			if err != nil {
-				log.Printf("cant parse replicaset uuid: %s", err)
+				log.Printf("Can't parse replicaset uuid: %s", err)
 
 				panic(err)
 			}

--- a/replicaset.go
+++ b/replicaset.go
@@ -269,7 +269,7 @@ func CalculateEtalonBalance(replicasets []Replicaset, bucketCount uint64) error 
 
 		// Safety check to prevent infinite loops
 		if stepCount > replicasetCount {
-			return fmt.Errorf("PANIC: the rebalancer is broken")
+			return fmt.Errorf("[PANIC]: the rebalancer is broken")
 		}
 	}
 

--- a/topology.go
+++ b/topology.go
@@ -45,7 +45,7 @@ func (r *Router) Topology() TopologyController {
 }
 
 func (r *Router) AddInstance(ctx context.Context, rsID uuid.UUID, info InstanceInfo) error {
-	r.log().Debugf(ctx, "trying to add instance %s to router topology in rs %s", info, rsID)
+	r.log().Debugf(ctx, "Trying to add instance %s to router topology in rs %s", info, rsID)
 
 	err := info.Validate()
 	if err != nil {
@@ -73,7 +73,7 @@ func (r *Router) AddInstance(ctx context.Context, rsID uuid.UUID, info InstanceI
 }
 
 func (r *Router) RemoveInstance(ctx context.Context, rsID, instanceID uuid.UUID) error {
-	r.log().Debugf(ctx, "trying to remove instance %s from router topology in rs %s", instanceID, rsID)
+	r.log().Debugf(ctx, "Trying to remove instance %s from router topology in rs %s", instanceID, rsID)
 
 	idToReplicasetRef := r.getIDToReplicaset()
 
@@ -86,7 +86,7 @@ func (r *Router) RemoveInstance(ctx context.Context, rsID, instanceID uuid.UUID)
 }
 
 func (r *Router) AddReplicaset(ctx context.Context, rsInfo ReplicasetInfo, instances []InstanceInfo) error {
-	r.log().Debugf(ctx, "trying to add replicaset %s to router topology", rsInfo)
+	r.log().Debugf(ctx, "Trying to add replicaset %s to router topology", rsInfo)
 
 	idToReplicasetOld := r.getIDToReplicaset()
 
@@ -169,7 +169,7 @@ func (r *Router) AddReplicasets(ctx context.Context, replicasets map[ReplicasetI
 }
 
 func (r *Router) RemoveReplicaset(ctx context.Context, rsID uuid.UUID) []error {
-	r.log().Debugf(ctx, "trying to remove replicaset %s from router topology", rsID)
+	r.log().Debugf(ctx, "Trying to remove replicaset %s from router topology", rsID)
 
 	idToReplicasetOld := r.getIDToReplicaset()
 

--- a/vshard.go
+++ b/vshard.go
@@ -173,7 +173,7 @@ func NewRouter(ctx context.Context, cfg Config) (*Router, error) {
 
 	err = cfg.TopologyProvider.Init(router.Topology())
 	if err != nil {
-		router.log().Errorf(ctx, "cant create new topology provider with err: %s", err)
+		router.log().Errorf(ctx, "Can't create new topology provider with err: %s", err)
 
 		return nil, fmt.Errorf("%w; cant init topology with err: %w", ErrTopologyProvider, err)
 	}


### PR DESCRIPTION
* linter: don't capitalize error strings and capitalize log
* fix misspellings

What has been done? Why? What problem is being solved?
See issue #75 

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
