### PR TITLE
partially resolve #100 (bucket_stat)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ REFACTOR:
 * Use constants for vshard error names and codes.
 * Reduce SLOC by using CallAsync method.
 * BucketForceCreate optimization: don't decode tnt response.
+* Remove bucketStatError type, use StorageCallVShardError type instead.
+* Add custom msgpackv5 decoder for 'vshard.storage.bucket_stat' response (partially #100).
+* Add custom msgpackv5 decoder for 'BucketStatInfo', since msgpackv5 library has an issue (see commit content).
 
 TESTS:
 * Rename bootstrap_test.go -> tarantool_test.go and new test in this file.

--- a/discovery.go
+++ b/discovery.go
@@ -88,8 +88,8 @@ func (r *Router) bucketSearchLegacy(ctx context.Context, bucketID uint64) (*Repl
 
 	for _, rsFuture := range rsFutures {
 		if _, err := bucketStatWait(rsFuture.future); err != nil {
-			var bsError bucketStatError
-			if !errors.As(err, &bsError) {
+			var vshardError StorageCallVShardError
+			if !errors.As(err, &vshardError) {
 				r.log().Errorf(ctx, "bucketSearchLegacy: bucketStatWait call error for %v: %v", rsFuture.rsID, err)
 			}
 			// just skip, bucket may not belong to this replicaset

--- a/error.go
+++ b/error.go
@@ -92,20 +92,6 @@ const (
 	VShardErrNameInstanceNameMismatch   = "INSTANCE_NAME_MISMATCH"
 )
 
-type bucketStatError struct {
-	BucketID uint64 `msgpack:"bucket_id"`
-	Reason   string `msgpack:"reason"`
-	Code     int    `msgpack:"code"`
-	Type     string `msgpack:"type"`
-	Message  string `msgpack:"message"`
-	Name     string `msgpack:"name"`
-}
-
-func (bse bucketStatError) Error() string {
-	type alias bucketStatError
-	return fmt.Sprintf("%+v", alias(bse))
-}
-
 func newVShardErrorNoRouteToBucket(bucketID uint64) error {
 	return &StorageCallVShardError{
 		Name:     VShardErrNameNoRouteToBucket,


### PR DESCRIPTION
* custom msgpackv5 decoders
* use StorageCallVShardError instead of bucketStatError

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
