### PR TITLE
review fixes for #105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 * Fix decoding fields for StorageCallVShardError (MasterUUID, ReplicasetUUID).
+* ClusterBootstrap: eliminate direct access to r.idToReplicaset.
 
 CHANGES:
 * Add comment why and how we handle "NON_MASTER" vshard error.
@@ -12,6 +13,7 @@ CHANGES:
 * Decode 'vshard.storage.call' response manually into struct vshardStorageCallResponseProto using DecodeMsgpack interface to reduce allocations (partially #61, #100).
 * Remove `mapstructure` tag from StorageCallVShardError.
 * Update benchmarks in README files.
+* Replace github links to master branch with permalinks.
 
 FEATURES:
 
@@ -26,6 +28,7 @@ REFACTOR:
 * Remove bucketStatError type, use StorageCallVShardError type instead.
 * Add custom msgpackv5 decoder for 'vshard.storage.bucket_stat' response (partially #100).
 * Add custom msgpackv5 decoder for 'BucketStatInfo', since msgpackv5 library has an issue (see commit content).
+* Hide router's concurrent data under interface 'routerConcurrentData' to prevent misusage by developers.
 
 TESTS:
 * Rename bootstrap_test.go -> tarantool_test.go and new test in this file.

--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ test: prepare-tnt
 cover: test ## Generate and open the HTML report for test coverage.
 	 $(GO_CMD) tool cover -html=coverage.out
 
-test/integration:
-	@$(MAKE) -C ./tests/integration test
-
 generate/mocks:
 	mockery --name=Pool --case=underscore --output=mocks/pool --outpkg=mockpool # need fix it later
 	mockery --name=TopologyController --case=underscore --output=mocks/topology --outpkg=mocktopology

--- a/api.go
+++ b/api.go
@@ -274,7 +274,7 @@ func (r *Router) RouterCallImpl(ctx context.Context,
 
 					var loggedOnce bool
 					for {
-						idToReplicasetRef := r.getIDToReplicaset()
+						idToReplicasetRef, _ := r.concurrentData.getRefs()
 						if _, ok := idToReplicasetRef[destinationUUID]; ok {
 							_, err := r.BucketSet(bucketID, destinationUUID)
 							if err == nil {
@@ -355,9 +355,9 @@ func (r *Router) RouterMapCallRWImpl(
 	}
 
 	timeStart := time.Now()
-	refID := r.refID.Add(1)
+	refID := r.concurrentData.nextRefID()
 
-	idToReplicasetRef := r.getIDToReplicaset()
+	idToReplicasetRef, _ := r.concurrentData.getRefs()
 
 	defer func() {
 		// call function "storage_unref" if map_callrw is failed or successed
@@ -509,11 +509,11 @@ func (r *Router) RouterRoute(ctx context.Context, bucketID uint64) (*Replicaset,
 }
 
 // RouterRouteAll return map of all replicasets.
-func (r *Router) RouterRouteAll() map[uuid.UUID]*Replicaset {
-	idToReplicasetRef := r.getIDToReplicaset()
+func (r *Router) RouterRouteAll() UUIDToReplicasetMap {
+	idToReplicasetRef, _ := r.concurrentData.getRefs()
 
 	// Do not expose the original map to prevent unauthorized modification.
-	idToReplicasetCopy := make(map[uuid.UUID]*Replicaset)
+	idToReplicasetCopy := make(UUIDToReplicasetMap)
 
 	for k, v := range idToReplicasetRef {
 		idToReplicasetCopy[k] = v

--- a/concurrent_data.go
+++ b/concurrent_data.go
@@ -1,0 +1,71 @@
+package vshard_router //nolint:revive
+
+import (
+	"sync"
+	"sync/atomic"
+
+	"github.com/google/uuid"
+)
+
+type UUIDToReplicasetMap map[uuid.UUID]*Replicaset
+
+type routerConcurrentData interface {
+	nextRefID() int64
+	getRefs() (UUIDToReplicasetMap, *consistentView)
+	setConsistentView(view *consistentView)
+	setIDToReplicaset(idToReplicasetNew UUIDToReplicasetMap)
+}
+
+// routerConcurrentDataImpl is the router's data that can be accessed concurrently.
+type routerConcurrentDataImpl struct {
+	mutex sync.RWMutex
+
+	// mutex guards not the map itself, but the variable idToReplicaset.
+	// idToReplicaset is an immutable object by our convention.
+	// Whenever we add or remove a replicaset, we create a new map object.
+	// idToReplicaset variable can be modified only by setIDToReplicaset method.
+	// Assuming that we rarely change idToReplicaset.
+	// it should be the simplest and most efficient way of handling concurrent access.
+	// Additionally, we can safely iterate over a map because it never changes.
+	idToReplicaset UUIDToReplicasetMap
+	// See comment for type consistentView.
+	view *consistentView
+
+	// ----------------------- Map-Reduce -----------------------
+	// Storage Ref ID. It must be unique for each ref request
+	// and therefore is global and monotonically growing.
+	refID atomic.Int64
+}
+
+func newRouterConcurrentData(totalBucketCount uint64) routerConcurrentData {
+	return &routerConcurrentDataImpl{
+		idToReplicaset: make(UUIDToReplicasetMap),
+		view: &consistentView{
+			routeMap: make([]atomic.Pointer[Replicaset], totalBucketCount+1),
+		},
+	}
+}
+
+func (d *routerConcurrentDataImpl) nextRefID() int64 {
+	return d.refID.Add(1)
+}
+
+func (d *routerConcurrentDataImpl) getRefs() (UUIDToReplicasetMap, *consistentView) {
+	d.mutex.RLock()
+	idToReplicasetRef, view := d.idToReplicaset, d.view
+	d.mutex.RUnlock()
+
+	return idToReplicasetRef, view
+}
+
+func (d *routerConcurrentDataImpl) setConsistentView(view *consistentView) {
+	d.mutex.Lock()
+	d.view = view
+	d.mutex.Unlock()
+}
+
+func (d *routerConcurrentDataImpl) setIDToReplicaset(idToReplicasetNew UUIDToReplicasetMap) {
+	d.mutex.Lock()
+	d.idToReplicaset = idToReplicasetNew
+	d.mutex.Unlock()
+}

--- a/discovery_test.go
+++ b/discovery_test.go
@@ -2,7 +2,6 @@ package vshard_router //nolint:revive
 
 import (
 	"context"
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -16,9 +15,7 @@ func TestRouter_BucketResolve_InvalidBucketID(t *testing.T) {
 			TotalBucketCount: uint64(10),
 			Loggerf:          emptyLogfProvider,
 		},
-		view: &consistentView{
-			routeMap: make([]atomic.Pointer[Replicaset], 11),
-		},
+		concurrentData: newRouterConcurrentData(10),
 	}
 
 	_, err := r.BucketResolve(ctx, 20)

--- a/replicaset.go
+++ b/replicaset.go
@@ -120,7 +120,7 @@ func bucketStatWait(future *tarantool.Future) (BucketStatInfo, error) {
 }
 
 // ReplicaCall perform function on remote storage
-// link https://github.com/tarantool/vshard/blob/master/vshard/replicaset.lua#L661
+// link https://github.com/tarantool/vshard/blob/99ceaee014ea3a67424c2026545838e08d69b90c/vshard/replicaset.lua#L661
 // This method is deprecated, because looks like it has a little bit broken interface
 func (rs *Replicaset) ReplicaCall(
 	ctx context.Context,
@@ -216,7 +216,7 @@ func (rs *Replicaset) bucketsDiscovery(ctx context.Context, from uint64) (bucket
 // At each iteration, the algorithm either concludes or disregards at least
 // one new overloaded replicaset. Therefore, its time complexity is O(N^2),
 // where N is the number of replicasets.
-// based on  https://github.com/tarantool/vshard/blob/master/vshard/replicaset.lua#L1358
+// based on https://github.com/tarantool/vshard/blob/99ceaee014ea3a67424c2026545838e08d69b90c/vshard/replicaset.lua#L1358
 func CalculateEtalonBalance(replicasets []Replicaset, bucketCount uint64) error {
 	isBalanceFound := false
 	weightSum := 0.0

--- a/tests/tnt/replicaset_test.go
+++ b/tests/tnt/replicaset_test.go
@@ -226,9 +226,7 @@ func TestReplicasetBucketsCount(t *testing.T) {
 
 	require.NoError(t, err, "NewRouter finished successfully")
 	for _, rs := range router.RouterRouteAll() {
-		count := uint64(0)
-
-		count, err = rs.BucketsCount(ctx)
+		count, err := rs.BucketsCount(ctx)
 		require.NoError(t, err)
 		require.NotEqual(t, count, 0)
 	}

--- a/topology_test.go
+++ b/topology_test.go
@@ -21,7 +21,7 @@ func TestController_AddInstance(t *testing.T) {
 
 	t.Run("no such replicaset", func(t *testing.T) {
 		router := Router{
-			idToReplicaset: map[uuid.UUID]*Replicaset{},
+			concurrentData: newRouterConcurrentData(1),
 			cfg: Config{
 				Loggerf: emptyLogfProvider,
 			},
@@ -36,7 +36,7 @@ func TestController_AddInstance(t *testing.T) {
 
 	t.Run("invalid instance info", func(t *testing.T) {
 		router := Router{
-			idToReplicaset: map[uuid.UUID]*Replicaset{},
+			concurrentData: newRouterConcurrentData(1),
 			cfg: Config{
 				Loggerf: emptyLogfProvider,
 			},
@@ -52,7 +52,7 @@ func TestController_RemoveInstance(t *testing.T) {
 
 	t.Run("no such replicaset", func(t *testing.T) {
 		router := Router{
-			idToReplicaset: map[uuid.UUID]*Replicaset{},
+			concurrentData: newRouterConcurrentData(1),
 			cfg: Config{
 				Loggerf: emptyLogfProvider,
 			},
@@ -71,8 +71,10 @@ func TestController_RemoveReplicaset(t *testing.T) {
 	mPool.On("CloseGraceful").Return(nil)
 
 	router := Router{
-		idToReplicaset: map[uuid.UUID]*Replicaset{
-			uuidToRemove: {conn: mPool},
+		concurrentData: &routerConcurrentDataImpl{
+			idToReplicaset: UUIDToReplicasetMap{
+				uuidToRemove: {conn: mPool},
+			},
 		},
 		cfg: Config{
 			Loggerf: emptyLogfProvider,
@@ -97,8 +99,10 @@ func TestRouter_AddReplicaset_AlreadyExists(t *testing.T) {
 	alreadyExistingRsUUID := uuid.New()
 
 	router := Router{
-		idToReplicaset: map[uuid.UUID]*Replicaset{
-			alreadyExistingRsUUID: {},
+		concurrentData: &routerConcurrentDataImpl{
+			idToReplicaset: UUIDToReplicasetMap{
+				alreadyExistingRsUUID: {},
+			},
 		},
 		cfg: Config{
 			Loggerf: emptyLogfProvider,

--- a/vshard_test.go
+++ b/vshard_test.go
@@ -1,7 +1,6 @@
 package vshard_router //nolint:revive
 
 import (
-	"sync/atomic"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -32,10 +31,8 @@ func TestRouter_RouterBucketCount(t *testing.T) {
 
 func TestRouter_RouteMapClean(t *testing.T) {
 	r := Router{
-		cfg: Config{TotalBucketCount: 10},
-		view: &consistentView{
-			routeMap: make([]atomic.Pointer[Replicaset], 10),
-		},
+		cfg:            Config{TotalBucketCount: 10},
+		concurrentData: newRouterConcurrentData(10),
 	}
 
 	require.NotPanics(t, func() {


### PR DESCRIPTION
* ClusterBootstrap: eliminate direct access to r.idToReplicaset
* replace github links to master branch with permalinks
* hide router's concurrent data under interface 'routerConcurrentData' to prevent misusage by developers

What has been done? Why? What problem is being solved?

I didn't forget about (remove if it is not applicable):

- [x] Changelog (see [documentation](https://keepachangelog.com/en/1.0.0/) for changelog format)

Related issues:
